### PR TITLE
Fix log message about ITX url

### DIFF
--- a/connections/ethereum/connection.go
+++ b/connections/ethereum/connection.go
@@ -78,7 +78,7 @@ func (c *Connection) Connect() error {
 	c.conn = ethclient.NewClient(rpcClient)
 	var itxRpc *rpc.Client
 	if c.itxEndpoint != nil {
-		c.log.Info("Connecting to ITX...", "url", c.itxEndpoint)
+		c.log.Info("Connecting to ITX...", "url", *c.itxEndpoint)
 		itxRpc, err = rpc.DialHTTP(*c.itxEndpoint)
 		if err != nil {
 			return err


### PR DESCRIPTION
Currently ITX url shows as pointer address on the logging. Fixed by de-referencing the pointer to get the value
INFO[08-16|13:00:17] Connecting to ITX...                     chain=rinkeby url=0xc00069f690
